### PR TITLE
Change setup to pass in provider to child module

### DIFF
--- a/00-init.tf
+++ b/00-init.tf
@@ -3,18 +3,11 @@ terraform {
     azurerm = {
       source                = "hashicorp/azurerm"
       version               = ">= 3.7.0"
-      configuration_aliases = [azurerm.postgres_network]
+      configuration_aliases = [azurerm.postgres_network, azurerm.sdp_vault]
     }
     random = {
       source  = "hashicorp/random"
       version = ">= 3.2.0"
     }
   }
-}
-
-provider "azurerm" {
-  features {}
-  skip_provider_registration = true
-  alias                      = "vault"
-  subscription_id            = local.environment[var.env].subscription
 }

--- a/00-init.tf
+++ b/00-init.tf
@@ -3,7 +3,7 @@ terraform {
     azurerm = {
       source                = "hashicorp/azurerm"
       version               = ">= 3.7.0"
-      configuration_aliases = [azurerm.postgres_network, azurerm.sdp_vault]
+      configuration_aliases = [azurerm.sdp_vault]
     }
     random = {
       source  = "hashicorp/random"

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -1,4 +1,4 @@
-variable "env" {
+variable "sdp_environment" {
   description = "Environment value."
   type        = string
 }

--- a/01-inputs-required.tf
+++ b/01-inputs-required.tf
@@ -1,4 +1,4 @@
-variable "sdp_environment" {
+variable "env" {
   description = "Environment value."
   type        = string
 }

--- a/02-inputs-optional.tf
+++ b/02-inputs-optional.tf
@@ -1,0 +1,11 @@
+variable "sdp_vault_name" {
+  description = "Name of the vault to store the SDP read user password in."
+  type        = string
+  default     = null
+}
+
+variable "sdp_vault_rg_name" {
+  description = "Name of the resource group the vault for the SDP read user password is in."
+  type        = string
+  default     = null
+}

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -4,37 +4,8 @@ data "azurerm_subscription" "current" {
 locals {
   sdp_read_user = "SDP_READ_USER"
 
-  sdp_cft_environments_map = {
-    sandbox  = "sbox"
-    aat      = "dev"
-    perftest = "test"
-  }
-
-  sdp_environment = lookup(local.sdp_cft_environments_map, var.env, var.env)
-
   sdp_vault = {
-    name = "mi-vault-${local.sdp_environment}"
-    rg   = "mi-${local.sdp_environment}-rg"
-  }
-
-  environment = {
-    sbox = {
-      subscription = "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
-    }
-    dev = {
-      subscription = "867a878b-cb68-4de5-9741-361ac9e178b6"
-    }
-    test = {
-      subscription = "3eec5bde-7feb-4566-bfb6-805df6e10b90"
-    }
-    ithc = {
-      subscription = "ba71a911-e0d6-4776-a1a6-079af1df7139"
-    }
-    stg = {
-      subscription = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
-    }
-    prod = {
-      subscription = "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
-    }
+    name = coalesce(var.sdp_vault_name, "mi-vault-${var.sdp_environment}")
+    rg   = coalesce(var.sdp_vault_rg_name, "mi-${var.sdp_environment}-rg")
   }
 }

--- a/03-interpolated-defaults.tf
+++ b/03-interpolated-defaults.tf
@@ -5,7 +5,7 @@ locals {
   sdp_read_user = "SDP_READ_USER"
 
   sdp_vault = {
-    name = coalesce(var.sdp_vault_name, "mi-vault-${var.sdp_environment}")
-    rg   = coalesce(var.sdp_vault_rg_name, "mi-${var.sdp_environment}-rg")
+    name = coalesce(var.sdp_vault_name, "mi-vault-${var.env}")
+    rg   = coalesce(var.sdp_vault_rg_name, "mi-${var.env}-rg")
   }
 }

--- a/20-setup-sdp-user.tf
+++ b/20-setup-sdp-user.tf
@@ -5,14 +5,14 @@ resource "random_password" "sdp_read_user_password" {
 }
 
 data "azurerm_key_vault" "sdp_vault" {
-  provider = azurerm.vault
+  provider = azurerm.sdp_vault
 
   name                = local.sdp_vault.name
   resource_group_name = local.sdp_vault.rg
 }
 
 resource "azurerm_key_vault_secret" "sdp_vault_sdp_read_user_password" {
-  provider = azurerm.vault
+  provider = azurerm.sdp_vault
 
   name         = "${var.server_name}-read-user-password"
   value        = random_password.sdp_read_user_password.result

--- a/20-setup-sdp-user.tf
+++ b/20-setup-sdp-user.tf
@@ -5,15 +5,11 @@ resource "random_password" "sdp_read_user_password" {
 }
 
 data "azurerm_key_vault" "sdp_vault" {
-  provider = azurerm.sdp_vault
-
   name                = local.sdp_vault.name
   resource_group_name = local.sdp_vault.rg
 }
 
 resource "azurerm_key_vault_secret" "sdp_vault_sdp_read_user_password" {
-  provider = azurerm.sdp_vault
-
   name         = "${var.server_name}-read-user-password"
   value        = random_password.sdp_read_user_password.result
   key_vault_id = data.azurerm_key_vault.sdp_vault.id

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ provider "azurerm" {
   features {}
   skip_provider_registration = true
   alias                      = "sdp_vault"
-  subscription_id            = local.sdp_environment_ids[local.sdp_environment].subscription
+  subscription_id            = local.sdp_environment_ids[local.sdp_environment].subscription # or var.sdp_subscription_id. See below.
 }
 ```
 
@@ -50,6 +50,8 @@ module "sdp_db_user" {
 variables.tf
 ```hcl
 variable "aks_subscription_id" {} # provided by the Jenkins library, ADO users will need to specify this
+
+variable "sdp_subscription_id" {} # either this or pass in the map as a local. See below.
 ```
 
 interpolated-defaults.tf
@@ -63,6 +65,7 @@ locals {
 
   sdp_environment = lookup(local.sdp_cft_environments_map, var.env, var.env)
 
+  # either this or pass in the SDS subscription ID as a variable. See above.
   sdp_environment_ids = {
     sbox = {
       subscription = "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ sdp_db_user.tf
 ```hcl
 module "sdp_db_user" {
   providers = {
-    azurerm.sdp_vault        = azurerm.sdp_vault
+    azurerm.sdp_vault = azurerm.sdp_vault
   }
   
   source = "git::https://github.com/hmcts/terraform-module-postgresql-flexible.git?ref=master"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ provider "azurerm" {
   alias                      = "postgres_network"
   subscription_id            = var.aks_subscription_id
 }
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "sdp_vault"
+  subscription_id            = local.sdp_environment_ids[local.sdp_environment].subscription
+}
 ```
 
 postgres.tf
@@ -23,10 +30,11 @@ module "sdp_db_user" {
 
   providers = {
     azurerm.postgres_network = azurerm.postgres_network
+    azurerm.sdp_vault        = azurerm.sdp_vault
   }
   
   source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"
-  env    = var.env
+  env    = local.sdp_environment
   
   server_name       = "${var.product}-${var.component}"
   server_fqdn       = module.terraform-module-postgres-flexible.fqdn
@@ -41,6 +49,40 @@ module "sdp_db_user" {
 variables.tf
 ```hcl
 variable "aks_subscription_id" {} # provided by the Jenkins library, ADO users will need to specify this
+```
+
+interpolated-defaults.tf
+```hcl
+locals {
+  sdp_cft_environments_map = {
+    sandbox  = "sbox"
+    aat      = "dev"
+    perftest = "test"
+  }
+
+  sdp_environment = lookup(local.sdp_cft_environments_map, var.env, var.env)
+
+  sdp_environment_ids = {
+    sbox = {
+      subscription = "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
+    }
+    dev = {
+      subscription = "867a878b-cb68-4de5-9741-361ac9e178b6"
+    }
+    test = {
+      subscription = "3eec5bde-7feb-4566-bfb6-805df6e10b90"
+    }
+    ithc = {
+      subscription = "ba71a911-e0d6-4776-a1a6-079af1df7139"
+    }
+    stg = {
+      subscription = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
+    }
+    prod = {
+      subscription = "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
+    }
+  }
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -14,34 +14,26 @@ provider "azurerm" {
 provider "azurerm" {
   features {}
   skip_provider_registration = true
-  alias                      = "postgres_network"
-  subscription_id            = var.aks_subscription_id
-}
-
-provider "azurerm" {
-  features {}
-  skip_provider_registration = true
   alias                      = "sdp_vault"
   subscription_id            = local.sdp_environment_ids[local.sdp_environment].subscription # or var.sdp_subscription_id. See below.
 }
 ```
 
-postgres.tf
+sdp_db_user.tf
 ```hcl
 module "sdp_db_user" {
   providers = {
-    azurerm.postgres_network = azurerm.postgres_network
     azurerm.sdp_vault        = azurerm.sdp_vault
   }
   
-  source = "git@github.com:hmcts/terraform-module-sdp-db-user?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-postgresql-flexible.git?ref=master"
   env    = local.sdp_environment
   
   server_name       = "${var.product}-${var.component}"
   server_fqdn       = module.terraform-module-postgres-flexible.fqdn
   server_admin_user = module.terraform-module-postgres-flexible.username
   server_admin_pass = module.terraform-module-postgres-flexible.password
-  databases         = var.databases
+  databases         = var.databases # [{"name": "database_name"}] format
   
   common_tags = var.common_tags
 }
@@ -49,8 +41,6 @@ module "sdp_db_user" {
 
 variables.tf
 ```hcl
-variable "aks_subscription_id" {} # provided by the Jenkins library, ADO users will need to specify this
-
 variable "sdp_subscription_id" {} # either this or pass in the map as a local. See below.
 ```
 
@@ -88,7 +78,6 @@ locals {
   }
 }
 ```
-
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Terraform module to add a read only SDP user to a specified databases.
 
 ## Example
 
+See the example directory for a more full example.
+
 provider.tf
 ```hcl
 provider "azurerm" {
@@ -27,7 +29,6 @@ provider "azurerm" {
 postgres.tf
 ```hcl
 module "sdp_db_user" {
-
   providers = {
     azurerm.postgres_network = azurerm.postgres_network
     azurerm.sdp_vault        = azurerm.sdp_vault

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module "sdp_db_user" {
     azurerm.sdp_vault = azurerm.sdp_vault
   }
   
-  source = "git::https://github.com/hmcts/terraform-module-postgresql-flexible.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-sdp-db-user.git?ref=master"
   env    = local.sdp_environment
   
   server_name       = "${var.product}-${var.component}"

--- a/example/interpolated-defaults.tf
+++ b/example/interpolated-defaults.tf
@@ -1,0 +1,30 @@
+locals {
+  sdp_cft_environments_map = {
+    sandbox  = "sbox"
+    aat      = "dev"
+    perftest = "test"
+  }
+
+  sdp_environment = lookup(local.sdp_cft_environments_map, var.env, var.env)
+
+  sdp_environment_ids = {
+    sbox = {
+      subscription = "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
+    }
+    dev = {
+      subscription = "867a878b-cb68-4de5-9741-361ac9e178b6"
+    }
+    test = {
+      subscription = "3eec5bde-7feb-4566-bfb6-805df6e10b90"
+    }
+    ithc = {
+      subscription = "ba71a911-e0d6-4776-a1a6-079af1df7139"
+    }
+    stg = {
+      subscription = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
+    }
+    prod = {
+      subscription = "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
+    }
+  }
+}

--- a/example/main.tf
+++ b/example/main.tf
@@ -4,7 +4,7 @@ module "postgresql" {
     azurerm.postgres_network = azurerm.postgres_network
   }
 
-  source = "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-postgresql-flexible.git?ref=master"
   env    = var.env
 
   product       = "sdp"
@@ -23,7 +23,6 @@ module "postgresql" {
 module "sdp_read_user" {
 
   providers = {
-    azurerm.postgres_network = azurerm.postgres_network
     azurerm.sdp_vault        = azurerm.sdp_vault
   }
   
@@ -46,7 +45,7 @@ module "sdp_read_user" {
 # only for use when building from ADO and as a quick example to get valid tags
 # if you are building from Jenkins use `var.common_tags` provided by the pipeline
 module "common_tags" {
-  source = "github.com/hmcts/terraform-module-common-tags?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-common-tags.git?ref=master"
 
   builtFrom   = "hmcts/terraform-module-sdp-db-user"
   environment = var.env

--- a/example/main.tf
+++ b/example/main.tf
@@ -23,7 +23,7 @@ module "postgresql" {
 module "sdp_read_user" {
 
   providers = {
-    azurerm.sdp_vault        = azurerm.sdp_vault
+    azurerm.sdp_vault = azurerm.sdp_vault
   }
   
   source = "../"

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,56 @@
+module "postgresql" {
+
+  providers = {
+    azurerm.postgres_network = azurerm.postgres_network
+  }
+
+  source = "git@github.com:hmcts/terraform-module-postgresql-flexible?ref=master"
+  env    = var.env
+
+  product       = "sdp"
+  component     = "example"
+  business_area = "sds"
+
+  common_tags = module.common_tags.common_tags
+  pgsql_databases = [
+    {
+      name : "application"
+    }
+  ]
+  pgsql_version = "14"
+}
+
+module "sdp_read_user" {
+
+  providers = {
+    azurerm.postgres_network = azurerm.postgres_network
+    azurerm.sdp_vault        = azurerm.sdp_vault
+  }
+  
+  source = "../"
+  env    = var.env
+
+  env    = local.sdp_environment
+
+  server_name       = "sdp-example"
+  server_fqdn       = module.postgresql.fqdn
+  server_admin_user = module.postgresql.username
+  server_admin_pass = module.postgresql.password
+  databases         = [
+    {
+      name : "application"
+    }
+  ]
+
+  common_tags = module.common_tags.common_tags
+}
+
+# only for use when building from ADO and as a quick example to get valid tags
+# if you are building from Jenkins use `var.common_tags` provided by the pipeline
+module "common_tags" {
+  source = "github.com/hmcts/terraform-module-common-tags?ref=master"
+
+  builtFrom   = "hmcts/terraform-module-sdp-db-user"
+  environment = var.env
+  product     = "sdp"
+}

--- a/example/main.tf
+++ b/example/main.tf
@@ -28,8 +28,6 @@ module "sdp_read_user" {
   }
   
   source = "../"
-  env    = var.env
-
   env    = local.sdp_environment
 
   server_name       = "sdp-example"

--- a/example/provider.tf
+++ b/example/provider.tf
@@ -1,0 +1,17 @@
+provider "azurerm" {
+  features {}
+}
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "postgres_network"
+  subscription_id            = var.aks_subscription_id
+}
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "sdp_vault"
+  subscription_id            = local.sdp_environment_ids[local.sdp_environment].subscription
+}

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,7 @@
+variable "env" {
+  default = "dev"
+}
+
+variable "aks_subscription_id" {
+  default = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}


### PR DESCRIPTION
Explciitly setting the provider when this is meant to be a re-usable module causes issues when the module has any changes which will affect any resources as part of the module that needs to be applied.

As this is meant to be specifically a child module for other shared infras, its more correct to pass in the provider, and setup the provider in the root module. The readme as been updated to add the example files.