### PR TITLE
Don't run database script until SDP user successfully saved to vault

### DIFF
--- a/20-setup-sdp-user.tf
+++ b/20-setup-sdp-user.tf
@@ -49,4 +49,9 @@ resource "null_resource" "setup_sdp_user" {
       DB_SDP_PASS     = random_password.sdp_read_user_password.result
     }
   }
+
+  depends_on = [
+    azurerm_key_vault_secret.sdp_vault_sdp_read_user_name,
+    azurerm_key_vault_secret.sdp_vault_sdp_read_user_password
+  ]
 }

--- a/setup-sdp-user.bash
+++ b/setup-sdp-user.bash
@@ -42,8 +42,6 @@ END
 psql "sslmode=require host=${DB_HOST_NAME} port=5432 dbname=${DB_NAME} user='${DB_ADMIN}'" -c "${SDP_SQL_COMMAND}"
 
 ## Validation
-export PGPASSWORD=$DB_SDP_PASS
-
 VALIDATE_COMMAND="SELECT * FROM information_schema.tables;"
 
-psql "sslmode=require host=${DB_HOST_NAME} port=5432 dbname=${DB_NAME} user='${DB_SDP_USER}'" -c "${VALIDATE_COMMAND}"
+PGPASSWORD=$DB_SDP_PASS psql "sslmode=require host=${DB_HOST_NAME} port=5432 dbname=${DB_NAME} user='${DB_SDP_USER}'" -c "${VALIDATE_COMMAND}"


### PR DESCRIPTION
Potentially script will run before vault secrets get added, or if vault secrets failed to add, the script will still attempt to run